### PR TITLE
Fix literal inside optional not working

### DIFF
--- a/discord/app.py
+++ b/discord/app.py
@@ -59,11 +59,12 @@ def _option_to_dict(option: _OptionData) -> dict:
         if arg.__args__[1] is NoneType:  # type: ignore
             payload["required"] = False
             arg = arg.__args__[0]  # type: ignore
-
+            origin = getattr(arg, "__origin__", None)
+            
         if arg == Union[Member, Role]:
             payload["type"] = 9
 
-    elif origin is Literal:
+    if origin is Literal:
         values = arg.__args__  # type: ignore
         python_type_ = type(values[0])
         if (


### PR DESCRIPTION
## Summary

Fixed literals inside optional not working

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
