### PR TITLE
Unifies upload for ext.commands and new implementation

### DIFF
--- a/discord/app.py
+++ b/discord/app.py
@@ -424,7 +424,7 @@ class CommandState:
             self._application_id = appinfo["id"]
 
         global_commands = self.pre_registration.get(None, [])
-        
+
         if global_commands:
             store = {(x._name_, x.type().value): x for x in global_commands}  # type: ignore
             data = [x.to_dict() for x in global_commands if not x._parent_]

--- a/discord/client.py
+++ b/discord/client.py
@@ -1737,8 +1737,8 @@ class Client:
     async def upload_global_application_commands(self) -> None:
         await self._application_command_store.upload_global_commands()
 
-    async def upload_guild_application_commands(self, guild: Guild = None) -> None:
-        await self._application_command_store.upload_guild_commands(guild)
+    async def upload_guild_application_commands(self, ext_commands: Dict[int | None, Any], guild: Guild = None) -> None:
+        await self._application_command_store.upload_guild_commands(ext_commands, guild)
 
     async def upload_guild_application_command_permissions(self, guild: Guild) -> None:
         await self._application_command_store.upload_guild_command_permissions(guild.id)

--- a/discord/client.py
+++ b/discord/client.py
@@ -1734,8 +1734,8 @@ class Client:
         """
         return self._connection.persistent_views
 
-    async def upload_global_application_commands(self) -> None:
-        await self._application_command_store.upload_global_commands()
+    async def upload_global_application_commands(self, ext_commands: Dict[int | None, Any]) -> None:
+        await self._application_command_store.upload_global_commands(ext_commands)
 
     async def upload_guild_application_commands(self, ext_commands: Dict[int | None, Any], guild: Guild = None) -> None:
         await self._application_command_store.upload_guild_commands(ext_commands, guild)

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -301,10 +301,10 @@ class BotBase(GroupMixin):
             else:
                 for guild in guilds:
                     commands[guild].append(payload)
-        
-        await self.upload_guild_application_commands(commands) # type: ignore
-        await self.upload_global_application_commands(commands) # type: ignore
-        
+
+        await self.upload_guild_application_commands(commands)  # type: ignore
+        await self.upload_global_application_commands(commands)  # type: ignore
+
     @discord.utils.copy_doc(discord.Client.close)
     async def close(self) -> None:
         for extension in tuple(self.__extensions):
@@ -1319,7 +1319,6 @@ class BotBase(GroupMixin):
             await self.process_slash_commands(interaction)
         except errors.CommandNotFound:
             await discord.Client.on_interaction(self, interaction)  # type: ignore
-
 
 
 class Bot(BotBase, discord.Client):

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -303,6 +303,7 @@ class BotBase(GroupMixin):
                     commands[guild].append(payload)
         
         await self.upload_guild_application_commands(commands) # type: ignore
+        await self.upload_global_application_commands(commands) # type: ignore
         
     @discord.utils.copy_doc(discord.Client.close)
     async def close(self) -> None:

--- a/discord/ext/commands/bot.py
+++ b/discord/ext/commands/bot.py
@@ -301,32 +301,9 @@ class BotBase(GroupMixin):
             else:
                 for guild in guilds:
                     commands[guild].append(payload)
-
-        http: HTTPClient = self.http  # type: ignore
-        global_commands = commands.pop(None, None)
-        application_id = self.application_id or (await self.application_info()).id  # type: ignore
-        if global_commands is not None:
-            if self.slash_command_guilds is None:
-                await http.bulk_upsert_global_commands(
-                    payload=global_commands,
-                    application_id=application_id,
-                )
-            else:
-                for guild in self.slash_command_guilds:
-                    await http.bulk_upsert_guild_commands(
-                        guild_id=guild,
-                        payload=global_commands,
-                        application_id=application_id,
-                    )
-
-        for guild, guild_commands in commands.items():
-            assert guild is not None
-            await http.bulk_upsert_guild_commands(
-                guild_id=guild,
-                payload=guild_commands,
-                application_id=application_id,
-            )
-
+        
+        await self.upload_guild_application_commands(commands) # type: ignore
+        
     @discord.utils.copy_doc(discord.Client.close)
     async def close(self) -> None:
         for extension in tuple(self.__extensions):
@@ -1337,8 +1314,11 @@ class BotBase(GroupMixin):
         await self.process_commands(message)
 
     async def on_interaction(self, interaction: discord.Interaction):
-        await discord.Client.on_interaction(self, interaction) # type: ignore
-        await self.process_slash_commands(interaction)
+        try:
+            await self.process_slash_commands(interaction)
+        except errors.CommandNotFound:
+            await discord.Client.on_interaction(self, interaction)  # type: ignore
+
 
 
 class Bot(BotBase, discord.Client):


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary

Unifies upload for ext.commands and new implementation

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
