### PR TITLE
Allow Option min and max values to be set to zero

### DIFF
--- a/discord/app.py
+++ b/discord/app.py
@@ -105,9 +105,9 @@ def _option_to_dict(option: _OptionData) -> dict:
         if option.min and option.max and option.min > option.max:
             raise ValueError(f"{option} has a min value that is greater than the max value")
 
-        if option.min:
+        if option.min is not MISSING:
             payload["min_value"] = option.min
-        if option.max:
+        if option.max is not MISSING:
             payload["max_value"] = option.max
 
     if origin is not Literal:


### PR DESCRIPTION
<!-- Pull requests that do not fill this information in will likely be closed -->

## Summary
This PR fixes a case when `Option` min and/or max values are set to zero.
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
